### PR TITLE
Added check of focus selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1
+* Do not process if there is a `:focus` selector already.
+
 ## 2.0
 * Use PostCSS 6.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.1
-* Do not process if there is a `:focus` selector already.
-
 ## 2.0
 * Use PostCSS 6.0.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ See also [postcss-pseudo-class-enter] for more explicit way.
 }
 ```
 
+If there is a `:focus` selector, it will be excluded from the processing.
+
+```css
+.a:hover, .b:hover {
+    outline: 0;
+}
+.b:focus {
+    background: red;
+}
+```
+
+```css
+.a:hover, .b:hover, .a:focus {
+    outline: 0;
+}
+.b:focus {
+    background: red;
+}
+```
+
 ## Usage
 
 ```js

--- a/index.js
+++ b/index.js
@@ -7,7 +7,12 @@ module.exports = postcss.plugin('postcss-focus', function () {
                 var focuses = [];
                 rule.selectors.forEach(function (selector) {
                     if ( selector.indexOf(':hover') !== -1 ) {
-                        focuses.push(selector.replace(/:hover/g, ':focus'));
+                        var replaced = selector.replace(/:hover/g, ':focus');
+                        if (!rule.parent.nodes.some(function (i) {
+                            return i.selector === replaced;
+                        })) {
+                            focuses.push(replaced);
+                        }
                     }
                 });
                 if ( focuses.length ) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = postcss.plugin('postcss-focus', function () {
                     if ( selector.indexOf(':hover') !== -1 ) {
                         var replaced = selector.replace(/:hover/g, ':focus');
                         if (!rule.parent.nodes.some(function (i) {
-                            return i.selector === replaced;
+                            return i.type === 'rule' &&
+                                   i.selectors.indexOf(replaced) !== -1;
                         })) {
                             focuses.push(replaced);
                         }

--- a/index.test.js
+++ b/index.test.js
@@ -17,3 +17,11 @@ it('adds focus selector', () => {
     return run('a:hover, b:hover {}',
                'a:hover, b:hover, a:focus, b:focus {}');
 });
+
+it('ignores hover selector because of focus', () => {
+    const before = 'a:hover, b:hover { color: white; } ' +
+                   'b:focus { color: black; } @media { b:hover { } }';
+    const after  = 'a:hover, b:hover, a:focus { color: white; } ' +
+                   'b:focus { color: black; } @media { b:hover, b:focus { } }';
+    return run(before, after);
+});


### PR DESCRIPTION
Hi, @ai!

I faced a problem on one of our projects when I tried to use different styling for `:hover` and `:focus` selectors. Unfortunately, `postcss-focus` does not take into account presence of manual `:focus` ones, so I decided to add this check function.

Please review and let me know if it should be improved.

Thanks!