### PR TITLE
Add splitRules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ to every `:hover`.
 
 Type: `boolean`. Default: `true`.
 
-Enable if you need to split the new selector into a separate rule. Use this if you need to support browsers, which doesn't support `:focus-visible`.
+Disable if you need to append the selector. If you don't need to support browsers, which doesn't support `:focus-visible`, you can safely disable this option.
 
 [official docs]: https://github.com/postcss/postcss#usage

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ module.exports = {
   plugins: [
     require('postcss-focus')({
       oldFocus: true,
-      splitRules: true,
+      splitRules: false,
     })
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ See also [postcss-pseudo-class-enter] for more explicit way.
 *:focus-visible {
   outline: 0;
 }
-.button:hover, .button:focus-visible {
+.button:hover {
+    background: red;
+}
+.button:focus-visible {
   background: red;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ module.exports = {
 module.exports = {
   plugins: [
     require('postcss-focus')({
-      oldFocus: true
+      oldFocus: true,
+      splitRules: true,
     })
   ]
 }
@@ -100,5 +101,11 @@ Type: `boolean`. Default: `false`.
 
 Enable if you need to add the old `:focus` instead of `:focus-visible` selector
 to every `:hover`.
+
+### `splitRules`
+
+Type: `boolean`. Default: `false`.
+
+Enable if you need to split the new selector into a separate rule. Use this if you need to support browsers, which doesn't support `:focus-visible`.
 
 [official docs]: https://github.com/postcss/postcss#usage

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ to every `:hover`.
 
 ### `splitRules`
 
-Type: `boolean`. Default: `false`.
+Type: `boolean`. Default: `true`.
 
 Enable if you need to split the new selector into a separate rule. Use this if you need to support browsers, which doesn't support `:focus-visible`.
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function hasAlready(parent, selector) {
 
 module.exports = (opts = {}) => {
   let pseudoClass = opts.oldFocus ? ':focus' : ':focus-visible'
+  let splitRules = typeof opts.splitRules === 'undefined' ? true : opts.splitRules
 
   return {
     postcssPlugin: 'postcss-focus',
@@ -21,7 +22,7 @@ module.exports = (opts = {}) => {
           }
         }
         if (focuses.length) {
-          if (opts.splitRules) {
+          if (splitRules) {
             let clone = rule.cloneAfter()
             clone.selectors = focuses;
           } else {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,12 @@ module.exports = (opts = {}) => {
           }
         }
         if (focuses.length) {
-          rule.selectors = rule.selectors.concat(focuses)
+          if (opts.splitRules) {
+            let clone = rule.cloneAfter()
+            clone.selectors = focuses;
+          } else {
+            rule.selectors = rule.selectors.concat(focuses)
+          }
         }
       }
     }

--- a/index.test.js
+++ b/index.test.js
@@ -20,6 +20,19 @@ test('supports old focus', async () => {
   })
 })
 
+test('supports split rules', async () => {
+  await run('a:hover, b {}', 'a:hover, b {}a:focus-visible {}', {
+    splitRules: true
+  })
+})
+
+test('supports split rules and old focus', async () => {
+  await run('a:hover, b {}', 'a:hover, b {}a:focus {}', {
+    oldFocus: true,
+    splitRules: true
+  })
+})
+
 test('adds focus selectors', async () => {
   await run(
     'a:hover, b:hover {}',

--- a/index.test.js
+++ b/index.test.js
@@ -11,32 +11,36 @@ async function run(input, output, opts = {}) {
 }
 
 test('adds focus selector', async () => {
-  await run('a:hover, b {}', 'a:hover, b, a:focus-visible {}')
+  await run('a:hover, b {}', 'a:hover, b, a:focus-visible {}', {
+    splitRules: false,
+  })
 })
 
 test('supports old focus', async () => {
   await run('a:hover, b {}', 'a:hover, b, a:focus {}', {
-    oldFocus: true
+    oldFocus: true,
+    splitRules: false,
   })
 })
 
 test('supports split rules', async () => {
-  await run('a:hover, b {}', 'a:hover, b {}a:focus-visible {}', {
-    splitRules: true
-  })
+  await run('a:hover, b {}', 'a:hover, b {}a:focus-visible {}')
 })
 
 test('supports split rules and old focus', async () => {
   await run('a:hover, b {}', 'a:hover, b {}a:focus {}', {
     oldFocus: true,
-    splitRules: true
+    splitRules: true,
   })
 })
 
 test('adds focus selectors', async () => {
   await run(
     'a:hover, b:hover {}',
-    'a:hover, b:hover, a:focus-visible, b:focus-visible {}'
+    'a:hover, b:hover, a:focus-visible, b:focus-visible {}',
+    {
+      splitRules: false,
+    }
   )
 })
 
@@ -49,7 +53,10 @@ test('ignores hover selector because of focus', async () => {
     '.foo:hover {} .foo:focus-visible {} ' +
       'a:hover, b:hover, a:focus-visible {} ' +
       'b:focus-visible {} ' +
-      '@media { b:hover, b:focus-visible {} }'
+      '@media { b:hover, b:focus-visible {} }',
+    {
+      splitRules: false,
+    }
   )
   await run(
     '.foo:hover {} .foo:focus {} ' +
@@ -60,7 +67,10 @@ test('ignores hover selector because of focus', async () => {
       'a:hover, b:hover, a:focus {} ' +
       'b:focus {} ' +
       '@media { b:hover, b:focus {} }',
-    { oldFocus: true }
+    {
+      oldFocus: true,
+      splitRules: false,
+    }
   )
 })
 


### PR DESCRIPTION
This PR makes it possible to split the generated selector into a separate rule for better browser support.

Resolves #24 